### PR TITLE
Add highlighting of selected agent

### DIFF
--- a/scripts/agentrig.lua
+++ b/scripts/agentrig.lua
@@ -1,0 +1,85 @@
+local agentrig = include( "gameplay/agentrig" ).rig
+local refresh_old = agentrig.refreshRenderFilter
+local cdefs = include( "client_defs" )
+local util = include( "modules/util" )
+
+
+-- FOR FILTERING THE RING
+local FILTER_COLORS = {
+-----------------these three look best for the 'ring' filter!!
+["CYAN_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=0/255,	g=252/255,	b=255/255,	a=1.0,	lum=1.5 },
+
+["WHITE_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=255/255,	g=255/255,	b=255/255,	a=1.0,	lum=1.75 },
+
+["BLUE_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=58/255,	g=165/255,	b=255/255,	a=1.0,	lum=1.5 },
+}
+
+-- this version colours the HUD circle at the agent's feet instead of the agent. In the table above, I have marked with *** the filters I think look best here. The others were all picked for agent filtering. - Hek
+
+function agentrig.refreshRenderFilter(self)
+	refresh_old(self)
+	
+	if self._renderFilterOverride then
+		self._prop:setRenderFilter( self._renderFilterOverride )
+	else
+		local unit = self._boardRig:getLastKnownUnit( self._unitID )
+		if unit then
+			self._prop:setPlayMode( self._playMode )
+			if unit:getTraits().selectedFilter and  self._HUDteamCircle then
+				local filter = FILTER_COLORS[unit:getTraits().selectedFilter] or cdefs.RENDER_FILTERS["default"]
+				self._HUDteamCircle:setRenderFilter( filter )
+			end
+		end
+	end
+
+end
+
+-- this version of the function will colour the unit instead of the HUD circle!
+
+-- FOR FILTERING THE UNIT
+-- local FILTER_COLORS = {
+
+-- -------- highlights
+-- ["CYAN_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=0/255,	g=252/255,	b=255/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ["BLUE_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=58/255,	g=165/255,	b=255/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ["GREEN_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=0/255,	g=255/255,	b=180/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ["YELLOW_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=247/255,	g=241/255,	b=148/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ["RED_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=255/255,	g=0/255,	b=0/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ["PURPLE_HILITE"] = { shader=KLEIAnim.SHADER_HILITE,			r=229/255,	g=8/255,	b=226/255,	a=1.0,	lum=1.0-0.46 },
+
+-- ------- shaders
+-- ["CYAN_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=0/255,	g=252/255,	b=255/255,	a=1.0,	lum=2 },
+
+-- ["BLUE_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=58/255,	g=165/255,	b=255/255,	a=1.0,	lum=2 },
+
+-- ["GREEN_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=0/255,	g=255/255,	b=180/255,	a=1.0,	lum=2 },
+
+-- ["YELLOW_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=247/255,	g=241/255,	b=148/255,	a=1.0,	lum=2 },
+
+-- ["RED_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=255/255,	g=0/255,	b=0/255,	a=1.0,	lum=2 },
+
+-- ["PURPLE_SHADE"] = { shader=KLEIAnim.SHADER_FOW,			r=229/255,	g=8/255,	b=226/255,	a=1.0,	lum=2 },
+-- }
+
+
+-- function agentrig.refreshRenderFilter(self)
+	-- refresh_old(self)
+	
+	-- if self._renderFilterOverride then
+		-- self._prop:setRenderFilter( self._renderFilterOverride )
+	-- else
+		-- local unit = self._boardRig:getLastKnownUnit( self._unitID )
+		-- if unit then
+			-- self._prop:setPlayMode( self._playMode )
+			-- if unit:getTraits().selectedFilter and FILTER_COLORS[unit:getTraits().selectedFilter] then
+				-- local filter = FILTER_COLORS[unit:getTraits().selectedFilter]
+				-- self._prop:setRenderFilter( filter )
+			-- end
+		-- end
+	-- end
+-- end

--- a/scripts/hud_select_hilite.lua
+++ b/scripts/hud_select_hilite.lua
@@ -1,0 +1,43 @@
+local sim = include("sim/engine")
+local cdefs = include("client_defs")
+local flagui = include("hud/flag_ui")
+local boardrig = include("gameplay/boardrig")
+local cellrig = include("gameplay/cellrig")
+local wallrig = include("gameplay/wallrig2")
+local simdefs = include("sim/simdefs")
+local simquery = include("sim/simquery")
+local hudFile = include( "hud/hud" )
+local util = include("modules/util")
+
+local oldCreateHud = hudFile.createHud
+-- thanks to Sizzlefrost for the bulk of this code!
+
+function hudFile.createHud(...)
+	local hud = oldCreateHud(...)
+
+	local oldOnSelectUnit = hud.onSelectUnit
+
+	local boardrig = hud._game.boardRig
+
+	function hud.onSelectUnit( self, prevUnit, selectedUnit, ... )
+		if prevUnit then
+			-- prevUnit:getTraits().selectedFilter = nil 
+			prevUnit:getTraits().selectedFilter = "default"
+		end
+		if selectedUnit and selectedUnit:getSim() and selectedUnit:isPC() then
+			local sim = selectedUnit:getSim()
+			local paramsColor = sim:getParams().difficultyOptions.uiTweaks and sim:getParams().difficultyOptions.uiTweaks.selectionFilter
+			if (paramsColor == nil) or (paramsColor ~= false) then
+				local filterColor = paramsColor or "WHITE_SHADE"
+				local unit = selectedUnit
+				unit:getTraits().selectedFilter = filterColor
+				-- sim:dispatchEvent( simdefs.EV_UNIT_REFRESH, { unit = unit } )
+			end			
+		end
+		boardrig:refresh()
+
+	    return oldOnSelectUnit( self, prevUnit, selectedUnit, ... )
+	end
+
+	return hud
+end

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -33,6 +33,22 @@ local function init( modApi )
 	})
 	modApi:addGenerationOption("step_carefully", STRINGS.UITWEAKSR.OPTIONS.STEP_CAREFULLY, STRINGS.UITWEAKSR.OPTIONS.STEP_CAREFULLY_TIP, { noUpdate=true })
 	modApi:addGenerationOption("xu_shank", STRINGS.UITWEAKSR.OPTIONS.XU_SHANK, STRINGS.UITWEAKSR.OPTIONS.XU_SHANK_TIP, { noUpdate=true })
+	
+	-- OLD: for agent filtering
+	-- modApi:addGenerationOption("selection_filter", STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER, STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER_TIP, {
+		-- noUpdate=true,
+		-- values={ false, "CYAN_SHADE", "CYAN_HILITE", "BLUE_SHADE", "BLUE_HILITE", },
+		-- value="CYAN_SHADE",
+		-- strings= STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER_COLORS,
+	-- })	
+	
+	-- NEW: for ring filtering
+	modApi:addGenerationOption("selection_filter", STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER, STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER_TIP, {
+		noUpdate=true,
+		values={ false, "CYAN_SHADE", "WHITE_SHADE", "BLUE_SHADE",},
+		value="WHITE_SHADE",
+		strings= STRINGS.UITWEAKSR.OPTIONS.SELECTION_FILTER_COLORS,
+	})		
 
 	local dataPath = modApi:getDataPath()
 	KLEIResourceMgr.MountPackage( dataPath .. "/gui.kwad", "data" )
@@ -55,6 +71,8 @@ local function init( modApi )
 	include( modApi:getScriptPath() .. "/hud" )
 	include( modApi:getScriptPath() .. "/engine" )
 	include( modApi:getScriptPath() .. "/simquery" )
+	include( modApi:getScriptPath() .. "/agentrig" )
+	include( modApi:getScriptPath() .. "/hud_select_hilite" )
 end
 
 -- load may be called multiple times with different options enabled
@@ -71,6 +89,7 @@ local function load( modApi, options, params )
 		params.uiTweaks.preciseAp = options["precise_ap"] and options["precise_ap"].value
 		params.uiTweaks.stepCarefully = options["step_carefully"] and options["step_carefully"].enabled
         params.uiTweaks.xuShank = options["xu_shank"] and options["xu_shank"].enabled
+		params.uiTweaks.selectionFilter = options["selection_filter"] and options["selection_filter"].value
 
 		-- Save a fake option, in case this gets a campaign toggle later
 		options["vision_mode"] = { enabled=true }

--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -21,6 +21,16 @@ local UI_TWEAKS_STRINGS =
 		STEP_CAREFULLY_TIP = "Agents prefer to avoid watched/noticed tiles, while still choosing a path with the shortest distance",
 		XU_SHANK = "XU SHANK",
 		XU_SHANK_TIP = "Tony jabs devices with his arm instead of pulling out a laptop, to better match the augment icon. (animation change)",
+		
+		-- OLD: for unit filter
+		-- SELECTION_FILTER = "SELECTED AGENT HIGHLIGHT",
+		-- SELECTION_FILTER_TIP = "Selected agent is highlighted in a bright color of your choice.",
+		-- SELECTION_FILTER_COLORS = {"OFF/VANILLA","CYAN SHADER", "CYAN HIGHLIGHT","BLUE SHADER", "BLUE HIGHLIGHT"},
+		
+		-- NEW: for ring filter
+		SELECTION_FILTER = "SELECTED AGENT HIGHLIGHT",
+		SELECTION_FILTER_TIP = "Selected agent's tile is highlighted in a bright color of your choice.",
+		SELECTION_FILTER_COLORS = {"OFF/VANILLA","CYAN", "BLUE", "WHITE"},		
 	},
 
 	UI =


### PR DESCRIPTION
Currently has both functional code for highlighting the square "ring" at the agent's feet as well as commented out code for highlighting the agent themselves.

Currently behaviour with pre-existing saves is to add the highlighter even if they don't have the generation option. Default selected highlighter is white (in the hud file).