### PR TITLE
Sprint Noise Preview

### DIFF
--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -28,6 +28,8 @@ local UI_TWEAKS_STRINGS = {
         COLORED_TRACKS_A = "PALETTE A",
         CLEAN_SHIFT = "SHIFT Hides Context Actions.",
         CLEAN_SHIFT_TIP = "Holding SHIFT hides targeted action icons, making it easier to select or move agents in crowded areas.\nThis is in addition to the vanilla keybinding where holding SHIFT highlights tiles watched by units under the cursor.",
+        SPRINT_NOISE_PREVIEW = "Sprint Noise Preview",
+        SPRINT_NOISE_PREVIEW_TIP = "While previewing sprint movement, highlights units that would hear the agent.",
         MAINFRAME_LAYOUT = "Mainframe Firewall Layout",
         MAINFRAME_LAYOUT_TIP = "If active, mainframe firewall indicators will shift to avoid overlap.",
 

--- a/scripts/uitr_util.lua
+++ b/scripts/uitr_util.lua
@@ -92,6 +92,12 @@ local UITR_OPTIONS = {
         check = true,
     },
     {
+        id = "sprintNoisePreview",
+        name = STRINGS.UITWEAKSR.OPTIONS.SPRINT_NOISE_PREVIEW,
+        tip = STRINGS.UITWEAKSR.OPTIONS.SPRINT_NOISE_PREVIEW_TIP,
+        check = true,
+    }, 
+    {
         id = "mainframeLayout",
         name = STRINGS.UITWEAKSR.OPTIONS.MAINFRAME_LAYOUT,
         tip = STRINGS.UITWEAKSR.OPTIONS.MAINFRAME_LAYOUT_TIP,


### PR DESCRIPTION
Highlights units that would hear you when you sprint. Bare-bones; no hotkey, no conditions, just "whenever you sprint, as long as the option is active, units get a sound bug-esque indicator above them".