### PR TITLE
absorb TacticalViewToggle mod

### DIFF
--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -52,6 +52,13 @@ local UI_TWEAKS_STRINGS = {
             "ON",
             "ALWAYS",
         },
+        TACTICAL_TOGGLE = "Tactical View Toggle",
+        TACTICAL_TOGGLE_TIP = "How to activate Tactical View\nHELD: Only while hotkey or button are pressed\nMIXED: Button toggles tactical view, inverted while hotkey is pressed\nTOGGLE: Hotkey and button toggle tactical view\nCREDIT: Mobbstar",
+        TACTICAL_TOGGLE_OPTIONS = { --
+            "HELD/VANILLA",
+            "MIXED",
+            "TOGGLE",
+        },
         CLEAN_SHIFT = "SHIFT Hides Context Actions.",
         CLEAN_SHIFT_TIP = "Holding SHIFT hides targeted action icons, making it easier to select or move agents in crowded areas.\nThis is in addition to the vanilla keybinding where holding SHIFT highlights tiles watched by units under the cursor.",
         SPRINT_NOISE_PREVIEW = "Sprint Noise Preview",

--- a/scripts/uitr_util.lua
+++ b/scripts/uitr_util.lua
@@ -150,6 +150,14 @@ local UITR_OPTIONS = {
         strings = STRINGS.UITWEAKSR.OPTIONS.TACTICAL_CLOUD_OPTIONS,
     },
     {
+        id = "tacticalToggle",
+        name = STRINGS.UITWEAKSR.OPTIONS.TACTICAL_TOGGLE,
+        tip = STRINGS.UITWEAKSR.OPTIONS.TACTICAL_TOGGLE_TIP,
+        values = {false, 1, 2},
+        value = 1,
+        strings = STRINGS.UITWEAKSR.OPTIONS.TACTICAL_TOGGLE_OPTIONS,
+    },
+    {
         id = "cleanShift",
         name = STRINGS.UITWEAKSR.OPTIONS.CLEAN_SHIFT,
         tip = STRINGS.UITWEAKSR.OPTIONS.CLEAN_SHIFT_TIP,


### PR DESCRIPTION
implements #9 

works with and without the standalone TVT mod

pending: deprecation of standalone mod (is there a clever way to phase it out of existing campaigns or should I simply remove it from workshop?)