### PR TITLE
noise indicator before priming EMP

### DIFF
--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -87,6 +87,8 @@ local function init(modApi)
 
     include(modApi:getScriptPath() .. "/hud/state-map-screen")
 
+    include(modApi:getScriptPath() .. "/patches/ability_prime_emp")
+
     if config.DEV then
         local debugDecoRig = include(modApi:getScriptPath() .. "/hud/uitrdebug_decorig")
         package.loaded["gameplay/uitrdebug_decorig"] = debugDecoRig

--- a/scripts/patches/ability_prime_emp.lua
+++ b/scripts/patches/ability_prime_emp.lua
@@ -1,0 +1,77 @@
+local abilitydefs = include("sim/abilitydefs")
+local simdefs = include("sim/simdefs")
+local simquery = include("sim/simquery")
+local mathutil = include("modules/mathutil")
+local uitr_util = include(SCRIPT_PATHS.qed_uitr .. "/uitr_util")
+
+local emp_tooltip = uitr_util.extractUpvalue(abilitydefs._abilities.prime_emp.onTooltip, "emp_tooltip")
+
+local _activate = emp_tooltip.activate
+emp_tooltip.activate = function(self, ...)
+    _activate(self, ...)
+
+    local displayOption = uitr_util.checkOption("sprintNoisePreview")
+    if not displayOption then
+        return
+    end
+
+    local x0, y0 = self._unit:getLocation()
+    local radius = simdefs.SOUND_RANGE_1
+    local sim = self._game.simCore
+    local player = sim:getPC()
+    local hearingUnits = {}
+
+    local cells = simquery.rasterCircle(sim, x0, y0, radius)
+    for i = 1, #cells, 2 do
+        local x1, y1 = cells[i], cells[i+1]
+        local cellId = simquery.toCellID(x1, y1)
+        if sim:canPlayerSee(player, x1, y1) then -- check real units
+            for _, unit in ipairs(sim:getCell(x1, y1).units) do
+                if unit:getTraits().hasHearing and sim:canPlayerSeeUnit(player, unit) and
+                    unit:getPlayerOwner() ~= player and not unit:isDown() then
+                    table.insert(hearingUnits, unit)
+                end
+            end
+        elseif player._ghost_cells[cellId] then -- check ghost units
+            for _, ghostUnit in ipairs(player._ghost_cells[cellId].units) do
+                local unit = uitr_util.getKnownUnitFromGhost(sim, ghostUnit)
+                if unit and ghostUnit:getTraits().hasHearing and
+                    ghostUnit:getPlayerOwner() ~= player and not unit:isDown() then
+                    table.insert(hearingUnits, unit)
+                end
+            end
+        end
+    end
+
+    local boardrig = self._game.boardRig
+    local noiseProps = {}
+    for _, unit in ipairs(hearingUnits) do
+        local unitrig = boardrig:getUnitRig(unit:getID())
+        wx, wy = boardrig:cellToWorld(unit:getLocation())
+
+        local prop = unitrig:createHUDProp(
+                "kanim_soundbug_overlay_alarm", "character", "alarm_loop",
+                boardrig:getLayer("ceiling"), nil, wx, wy)
+
+        local r, g, b, a = 247 / 255, 247 / 255, 142 / 255, 1
+        prop:setSymbolModulate("cicrcle_wave", r, g, b, a)
+        prop:setSymbolModulate("line_1", r, g, b, a)
+        prop:setSymbolModulate("ring", r, g, b, a)
+        prop:setSymbolModulate("attention_ring", r, g, b, a)
+
+        table.insert(noiseProps, prop)
+    end
+    self.noiseProps = noiseProps
+end
+
+local _deactivate = emp_tooltip.deactivate
+emp_tooltip.deactivate = function(self, ...)
+    _deactivate(self, ...)
+
+    if self.noiseProps then
+        local layer = self._game.boardRig:getLayer("ceiling")
+        for _, prop in ipairs(self.noiseProps) do
+            layer:removeProp(prop)
+        end
+    end
+end


### PR DESCRIPTION
UI Tweaks Reloaded has noise indicators for sprinting.
EMP make noise.
This MR reuses the existing indicators for previewing the EMP noise. (Specifically, affected guards have the soundbug fx above them. The noise radius itself cannot be previewed because it'd conflict with the actual effect preview.)

To best of my knowledge, there are no modded EMP with different noise radius. If that is the case, the `radius` variable can be set accordingly.

This feature currently assumes it is desired alongside the sprint noise indicators. I recommend collecting user feedback and only adding a separate option if requested.